### PR TITLE
Changed the way item pricing is set - no messenger changes

### DIFF
--- a/controllers/company.js
+++ b/controllers/company.js
@@ -13,12 +13,11 @@ router.param('companyId', (req, res, next, id) => {
   return next();
 });
 
-
-
 router.get('/:companyId', (req, res) => {
   console.log("------ getting company menu -------", req.params.companyId);
   return getMenu(req.params.companyId)
     .then(data => {
+      console.log("This is the object being passed to the .ejs files: " + JSON.stringify(data));
       return res.render('account/company', {
         fbid: data.fbid,
         title: data.name,
@@ -96,14 +95,29 @@ function addItem(req, res, next) {
         .then(data => {
           return next();
         });
+
     case "size":
       return companyRepo.insertSize(req.body)
         .then(() => next());
+
+    case "iprice":
+      return companyRepo.updateIPrice(req.body)
+        .then(() => next());
+
+    case "tprice":
+      return companyRepo.updateTPrice(req.body)
+        .then(() => next());
+
+    case "sprice":
+      return companyRepo.updateSPrice(req.body)
+        .then(() => next());
+
     case "delete":
       console.log("DELETAIN *********");
       console.log("body = ", req.body);
       return companyRepo.deleteItem(req.body)
         .then(() => next());
+
     default:
       return console.error("no case for this update intent", req.body.intent);
     }

--- a/database/models/index.js
+++ b/database/models/index.js
@@ -114,6 +114,9 @@ const Item = sequelize.define('Item', {
   photo: {
     type: Sequelize.STRING
   },
+  price: {
+    type: Sequelize.DECIMAL
+  }
 }, {
   tableName: 'items',
   timestamps: false,
@@ -153,6 +156,9 @@ const Type = sequelize.define('Type', {
   photo: {
     type: Sequelize.STRING
   },
+  price: {
+    type: Sequelize.DECIMAL
+  }
 }, {
   tableName: 'types',
   timestamps: false,
@@ -184,8 +190,7 @@ const Size = sequelize.define('Size', {
     type: Sequelize.STRING
   },
   price: {
-    type: Sequelize.DECIMAL,
-    allowNull: false
+    type: Sequelize.DECIMAL
   }
 }, {
   tableName: 'sizes',

--- a/public/css/menubot.less
+++ b/public/css/menubot.less
@@ -85,7 +85,8 @@
   min-height: 125px;
 }
 
-//Experemental changes
+
+//menu classes
 
 .seprator {
   height: 100px;
@@ -104,6 +105,7 @@
 .item-heading-inner-container {
   padding-left: 15px;
   padding-top: 10px;
+  padding-right: 15px;
 }
 
 .item-remove-button {
@@ -123,9 +125,21 @@
   font-size: 30px;
 }
 
+.item-price {
+  float: right;
+  font-size: 30px;
+  color: grey;
+  text-decoration: line-through;
+}
+
+.item-price-input {
+  margin-top:-10px;
+}
+
 .item-content-inner-container {
   margin-left: 16px;
   margin-right: 16px;
+
 }
 
 .item-input-inner-container {
@@ -143,8 +157,9 @@
 }
 
 .type-heading-inner-container {
-  padding-left: 25px;
+  padding-left: 15px;
   padding-top: 10px;
+  padding-right: 15px;
 }
 
 .type-remove-button {
@@ -185,8 +200,15 @@
 }
 
 .size-heading-inner-container {
-  padding-left: 25px;
+  padding-left: 12px;
   padding-top: 10px;
+  padding-right: 15px;
+}
+
+.new-size-heading-inner-container {
+  padding-left: 30px;
+  padding-top: 10px;
+  padding-right: 15px;
 }
 
 .size-remove-button {
@@ -215,3 +237,51 @@
   padding-left: 11px;
   margin-bottom: 11px;
 }
+
+
+//Tooltip css
+
+#tooltip
+{
+    text-align: center;
+    color: #fff;
+    background: #111;
+    position: absolute;
+    z-index: 100;
+    padding: 15px;
+}
+
+    #tooltip:after /* triangle decoration */
+    {
+        width: 0;
+        height: 0;
+        border-left: 10px solid transparent;
+        border-right: 10px solid transparent;
+        border-top: 10px solid #111;
+        content: '';
+        position: absolute;
+        left: 50%;
+        bottom: -10px;
+        margin-left: -10px;
+    }
+
+        #tooltip.top:after
+        {
+            border-top-color: transparent;
+            border-bottom: 10px solid #111;
+            top: -20px;
+            bottom: auto;
+        }
+
+        #tooltip.left:after
+        {
+            left: 10px;
+            margin: 0;
+        }
+
+        #tooltip.right:after
+        {
+            right: 10px;
+            left: auto;
+            margin: 0;
+        }

--- a/public/js/submit.js
+++ b/public/js/submit.js
@@ -142,3 +142,80 @@ $(document).ready(function() {
   // });
 
 });
+
+$( function()
+{
+  var targets = $( '[rel~=tooltip]' ),
+      target  = false,
+      tooltip = false,
+      title   = false;
+
+  targets.bind( 'mouseenter', function()
+  {
+      target  = $( this );
+      tip     = target.attr( 'title' );
+      tooltip = $( '<div id="tooltip"></div>' );
+
+      if( !tip || tip == '' )
+          return false;
+
+      target.removeAttr( 'title' );
+      tooltip.css( 'opacity', 0 )
+             .html( tip )
+             .appendTo( 'body' );
+
+      var init_tooltip = function()
+      {
+          if( $( window ).width() < tooltip.outerWidth() * 1.5 )
+              tooltip.css( 'max-width', $( window ).width() / 2 );
+          else
+              tooltip.css( 'max-width', 340 );
+
+          var pos_left = target.offset().left + ( target.outerWidth() / 2 ) - ( tooltip.outerWidth() / 2 ),
+              pos_top  = target.offset().top - tooltip.outerHeight() - 20;
+
+          if( pos_left < 0 )
+          {
+              pos_left = target.offset().left + target.outerWidth() / 2 - 20;
+              tooltip.addClass( 'left' );
+          }
+          else
+              tooltip.removeClass( 'left' );
+
+          if( pos_left + tooltip.outerWidth() > $( window ).width() )
+          {
+              pos_left = target.offset().left - tooltip.outerWidth() + target.outerWidth() / 2 + 20;
+              tooltip.addClass( 'right' );
+          }
+          else
+              tooltip.removeClass( 'right' );
+
+          if( pos_top < 0 )
+          {
+              var pos_top  = target.offset().top + target.outerHeight();
+              tooltip.addClass( 'top' );
+          }
+          else
+              tooltip.removeClass( 'top' );
+
+          tooltip.css( { left: pos_left, top: pos_top } )
+                 .animate( { top: '+=10', opacity: 1 }, 50 );
+      };
+
+      init_tooltip();
+      $( window ).resize( init_tooltip );
+
+      var remove_tooltip = function()
+      {
+          tooltip.animate( { top: '-=10', opacity: 0 }, 50, function()
+          {
+              $( this ).remove();
+          });
+
+          target.attr( 'title', tip );
+      };
+
+      target.bind( 'mouseleave', remove_tooltip );
+      tooltip.bind( 'click', remove_tooltip );
+  });
+});

--- a/repositories/CompanyRepository.js
+++ b/repositories/CompanyRepository.js
@@ -15,27 +15,30 @@ exports.findCompany = (id) => Company.findById(id);
 
 exports.getCompanyMenu = id => {
   return sequelize.query(
-    "SELECT companies.name, items.item, items.itemid, items.photo FROM companies" +
+    "SELECT companies.name, items.item, items.itemid, items.photo, items.price FROM companies" +
     " INNER JOIN items ON companies.fbid = items.fbid" +
-    " WHERE companies.fbid = $1",
+    " WHERE companies.fbid = $1" +
+    " ORDER BY itemid ASC",
     { bind: [id], type: sequelize.QueryTypes.SELECT }
   );
 };
 
 exports.getMenuTypes = itemids => {
   return sequelize.query(
-    "SELECT types.itemid, type, typeid, types.photo FROM items" +
+    "SELECT types.itemid, type, typeid, types.photo, types.price FROM items" +
     " INNER JOIN types ON items.itemid = types.itemid" +
-    " WHERE items.itemid IN (:itemids)",
+    " WHERE items.itemid IN (:itemids)" +
+    " ORDER BY typeid ASC",
     { replacements: { itemids }, type: sequelize.QueryTypes.SELECT }
   );
 };
 
 exports.getMenuSizes = typeids => {
   return sequelize.query(
-    "SELECT sizes.typeid, size, sizeid, price FROM types" +
+    "SELECT sizes.typeid, size, sizeid, sizes.price FROM types" +
     " INNER JOIN sizes ON types.typeid = sizes.typeid" +
-    " WHERE types.typeid IN (:typeids)",
+    " WHERE types.typeid IN (:typeids)" +
+    " ORDER BY sizeid ASC",
     { replacements: { typeids }, type: sequelize.QueryTypes.SELECT }
   );
 };
@@ -71,9 +74,36 @@ exports.insertType = data => {
 
 exports.insertSize = data => {
   return sequelize.query(
-    "INSERT INTO sizes (typeid, size, price)" +
-    " VALUES (:typeid, :size, :price)",
-    { replacements: { typeid: data.parentId, size: data.size, price: data.price }, type: sequelize.QueryTypes.INSERT }
+    "INSERT INTO sizes (typeid, size)" +
+    " VALUES (:typeid, :size)",
+    { replacements: { typeid: data.parentId, size: data.size}, type: sequelize.QueryTypes.INSERT }
+  );
+};
+
+exports.updateIPrice = data => {
+  return sequelize.query(
+    "UPDATE ONLY items" +
+    " SET price = :price" +
+    " WHERE itemid = :itemid",
+    { replacements: { itemid: data.parentId, price: data.price}, type: sequelize.QueryTypes.UPDATE }
+  );
+};
+
+exports.updateTPrice = data => {
+  return sequelize.query(
+    "UPDATE ONLY types" +
+    " SET price = :price" +
+    " WHERE typeid = :typeid",
+    { replacements: { typeid: data.parentId, price: data.price}, type: sequelize.QueryTypes.UPDATE }
+  );
+};
+
+exports.updateSPrice = data => {
+  return sequelize.query(
+    "UPDATE ONLY sizes" +
+    " SET price = :price" +
+    " WHERE sizeid = :sizeid",
+    { replacements: { sizeid: data.parentId, price: data.price}, type: sequelize.QueryTypes.UPDATE }
   );
 };
 

--- a/views/menu/items.ejs
+++ b/views/menu/items.ejs
@@ -3,8 +3,50 @@
       <div class="row item-outer-container">
         <div class="col-xs-12 ">
           <div class="row item-heading-inner-container">
-            <button type="button" name="item-<%= items[i].itemid %>" class="item-remove-button"><i class="fa fa-trash-o item-remove-button-glyph" aria-hidden="true"></i></button>
-            <p class="item-title"><%= items[i].item %></p>
+            <div class="col-xs-6">
+              <button type="button" name="item-<%= items[i].itemid %>" class="item-remove-button"><i class="fa fa-trash-o item-remove-button-glyph" aria-hidden="true"></i></button>
+              <p class="item-title"><%= items[i].item %></p>
+            </div>
+
+            <%
+            var hasTypeChild = false;
+             for (var x = 0; x < types.length; x++) {
+               if (types[x].itemid == items[i].itemid) {
+                 hasTypeChild = true;
+                 break;
+               }
+             }
+
+             if (hasTypeChild) { %>
+              <div class="col-xs-6">
+                <form style="float:right;" class="form-inline">
+                  <div class="form-group-lg" >
+
+                    <abbr rel="tooltip" title="The price of this item is no longer changed here. It is now set in it's types.">
+                      <div class="input-group">
+                        <div class="input-group-addon">$</div>
+                        <!-- This tag needs to remain one line, no indentation allowed -->
+                        <input name="price" type="text" <% if (items[i].price == null) { %> value="" <% } else { %> value="<%= items[i].price %>" <% } %> size="10" class="form-control" placeholder="Price" disabled>
+                      </div>
+                    </abbr>
+
+                  </div>
+                </form>
+              </div>
+            <% } else { %>
+              <div class="col-xs-6">
+                <form id="new-iprice-<%= items[i].itemid %>" name="<%= items[i].itemid %>" style="float:right;" class="form-inline">
+                  <div class="form-group-lg" >
+                    <div class="input-group">
+                      <div class="input-group-addon">$</div>
+                      <input name="price" type="text" <% if (items[i].price == null) { %> value="" <% } else { %> value="<%= items[i].price %>" <% } %> size="10" class="form-control" placeholder="Price">
+                    </div>
+                  </div>
+                </form>
+              </div>
+            <% } %>
+
+            <div style="clear:both;"></div>
           </div>
           <div class="row item-content-inner-container">
             <img src="<%= items[i].photo ? items[i].photo : "" %>" class="thumbnail menu-photo" />

--- a/views/menu/new-size.ejs
+++ b/views/menu/new-size.ejs
@@ -1,15 +1,11 @@
-<div class="row size-heading-inner-container">
+<div class="row new-size-heading-inner-container">
   <p class="size-title">Create New Size</p>
 </div>
 <div class="row size-input-inner-container">
   <div class="col-xs-11 col-md-6">
     <form id="new-size-<%= types[x].typeid %>" name="<%= types[x].typeid %>" class="form-inline">
         <div class="form-group">
-          <input type="text" class="form-control" name="size" placeholder="Size name (eg: Large)" required autocomplete="off">
-          <div class="input-group">
-              <span class="input-group-addon">$</span>
-              <input type="text" class="form-control" name="price" aria-label="price" placeholder="Price" required autocomplete="off">
-          </div>
+          <input type="text" class="form-control" name="size" placeholder="Size name (eg: Large)" autocomplete="off">
         </div>
         <button type="submit" id="button-size" class="btn btn-default btn-space hidden">Submit</button>
     </form>

--- a/views/menu/new-type.ejs
+++ b/views/menu/new-type.ejs
@@ -1,5 +1,5 @@
 <div class="row type-heading-inner-container">
-  <p class="type-title">Create New Type</p>
+  <p style="margin-left:11px;" class="type-title">Create New Type</p>
 </div>
 <div class="row type-input-inner-container">
   <div class="col-xs-11 col-md-6">

--- a/views/menu/sizes.ejs
+++ b/views/menu/sizes.ejs
@@ -6,8 +6,24 @@
           <div class="col-xs-10">
             <div class="row size-outer-container">
               <div class="row size-heading-inner-container">
-                <button type="button" name="size-<%= sizes[y].sizeid %>" class="size-remove-button"><i class="fa fa-trash-o size-remove-button-glyph" aria-hidden="true"></i></button>
-                <p class="size-title"><%= sizes[y].size %>: $<%= sizes[y].price %></p>
+
+                <div class="col-xs-6">
+                  <button type="button" name="size-<%= sizes[y].sizeid %>" class="size-remove-button"><i class="fa fa-trash-o size-remove-button-glyph" aria-hidden="true"></i></button>
+                  <p class="size-title"><%= sizes[y].size %></p>
+                </div>
+
+                <div class="col-xs-6">
+                  <form id="new-sprice-<%= sizes[y].sizeid %>" name="<%= sizes[y].sizeid %>" style="float:right;" class="form-inline">
+                    <div class="form-group" >
+                      <div class="input-group">
+                        <div class="input-group-addon">$</div>
+                        <!-- This tag needs to remain one line, no indentation allowed -->
+                        <input name="price" type="text" <% if (sizes[y].price === null) { %> value="" <% } else { %> value="<%= sizes[y].price %>" <% } %> size="10" class="form-control" placeholder="Price">
+                      </div>
+                    </div>
+                  </form>
+                </div>
+
               </div>
             </div>
           </div>

--- a/views/menu/types.ejs
+++ b/views/menu/types.ejs
@@ -9,8 +9,50 @@
             <div class="row type-outer-container">
 
               <div class="row type-heading-inner-container">
-                <button type="button" name="type-<%= types[x].typeid %>" class="type-remove-button"><i class="fa fa-trash-o type-remove-button-glyph" aria-hidden="true"></i></button>
-                <p class="type-title"><%= types[x].type %></p>
+                <div class="col-xs-6">
+                  <button type="button" name="type-<%= types[x].typeid %>" class="type-remove-button"><i class="fa fa-trash-o type-remove-button-glyph" aria-hidden="true"></i></button>
+                  <p class="type-title"><%= types[x].type %></p>
+                </div>
+
+                <%
+                var hasSizeChild = false;
+                 for (var y = 0; y < sizes.length; y++) {
+                   if (sizes[y].typeid == types[x].typeid) {
+                     hasSizeChild = true;
+                     break;
+                   }
+                 }
+
+                 if (hasSizeChild) { %>
+                   <div class="col-xs-6">
+                     <form id="new-tprice-<%= types[x].typeid %>" name="<%= types[x].typeid %>" style="float:right;" class="form-inline">
+                       <div class="form-group-lg" >
+
+                         <abbr rel="tooltip" title="The price of this type is no longer changed here. It is now set in it's sizes.">
+                           <div class="input-group">
+                             <div class="input-group-addon">$</div>
+                             <!-- This tag needs to remain one line, no indentation allowed -->
+                             <input name="price" type="text" <% if (types[x].price === null) { %> value="" <% } else { %> value="<%= types[x].price %>" <% } %> size="10" class="form-control" placeholder="Price" disabled >
+                           </div>
+                        </abbr>
+
+                       </div>
+                     </form>
+                   </div>
+                <% } else { %>
+                  <div class="col-xs-6">
+                    <form id="new-tprice-<%= types[x].typeid %>" name="<%= types[x].typeid %>" style="float:right;" class="form-inline">
+                      <div class="form-group-lg" >
+                        <div class="input-group">
+                          <div class="input-group-addon">$</div>
+                          <!-- This tag needs to remain one line, no indentation allowed -->
+                          <input name="price" type="text" <% if (types[x].price === null) { %> value="" <% } else { %> value="<%= types[x].price %>" <% } %> size="10" class="form-control" placeholder="Price">
+                        </div>
+                      </div>
+                    </form>
+                  </div>
+                <% } %>
+
               </div>
 
               <div class="row type-content-inner-container">


### PR DESCRIPTION
This changes the UI and backend to allow for price to be set individually for items and types, along with sizes. Thus, a client can add an item without a type or size, but still be able to set a price for that item. These changes have not been implemented in the messenger yet, so the end user won't see the item/type prices.
