### PR TITLE
allow retry order times

### DIFF
--- a/classes/Message.js
+++ b/classes/Message.js
@@ -31,7 +31,6 @@ class Message {
       return db.getTimezone(this.recipient)
         .then(data => runActions(this.sender, this.recipient, this.text, this.timestamp, data.timezone))
         .then(resp => this.reply(resp))
-        .then(() => redisDeleteOrder(this.sender))
         .catch(err => this.reply(err));
     }
   }


### PR DESCRIPTION
no longer delete order details stored in redis. You can now retry order times

downside (?) is that you can retry times even if they’re successful & keep making orders